### PR TITLE
fix: echo route syntax uses `:id` not `{id}`

### DIFF
--- a/adapter/echoopenapi/README.MD
+++ b/adapter/echoopenapi/README.MD
@@ -54,7 +54,7 @@ func main() {
 	auth := v1.Group("", AuthMiddleware).With(
 		option.GroupSecurity("bearerAuth"),
 	)
-	auth.GET("/users/{id}", GetUserHandler).With(
+	auth.GET("/users/:id", GetUserHandler).With(
 		option.Summary("Get user by ID"),
 		option.Request(new(GetUserRequest)),
 		option.Response(200, new(User)),

--- a/adapter/echoopenapi/examples/basic/main.go
+++ b/adapter/echoopenapi/examples/basic/main.go
@@ -29,7 +29,7 @@ func main() {
 	auth := v1.Group("", AuthMiddleware).With(
 		option.GroupSecurity("bearerAuth"),
 	)
-	auth.GET("/users/{id}", GetUserHandler).With(
+	auth.GET("/users/:id", GetUserHandler).With(
 		option.Summary("Get user by ID"),
 		option.Request(new(GetUserRequest)),
 		option.Response(200, new(User)),


### PR DESCRIPTION
If you run the echo example with `go run adapter/echoopenapi/examples/basic/main.go`, prior to this patch you'd get a 404 from:

```text
curl --request POST \
  --url http://localhost:3000/api/v1/login \
  --header 'Accept: application/json' \
  --header 'Content-Type: application/json' \
  --data '{
  "password": "foo",
  "username": "bar"
}'
```

With this fix you get a response.

However, the fixed response reveals a deeper issue: in Echo you sepcify path params with the `param` struct tag, not `path`. So The above request now returns `{"id":"","name":"John Doe"}` but we expect `{"id":"123","name":"John Doe"}`. I'll raise this separately in an issue.