### PR TITLE
Fix/regex in path params

### DIFF
--- a/examples/petstore/main.go
+++ b/examples/petstore/main.go
@@ -28,10 +28,13 @@ func main() {
 		option.Request(new(Pet)),
 		option.Response(201, new(Pet)),
 	)
-	pet.Get("/findByStatus",
+	pet.Get(
+		"/findByStatus",
 		option.OperationID("findPetsByStatus"),
 		option.Summary("Find pets by status"),
-		option.Description("Finds Pets by status. Multiple status values can be provided with comma separated strings."),
+		option.Description(
+			"Finds Pets by status. Multiple status values can be provided with comma separated strings.",
+		),
 		option.Request(new(struct {
 			Status string `query:"status" enum:"available,pending,sold"` // Enum values for pet status
 		})),

--- a/internal/builder/builder.go
+++ b/internal/builder/builder.go
@@ -171,7 +171,7 @@ func (b *Builder) ensurePathParameters(target string, op *openapi.Operation) {
 		return
 	}
 	for _, m := range matches {
-		name := m[1]
+		name, _, _ := strings.Cut(m[1], ":")
 		if _, ok := existing[name]; ok {
 			continue
 		}

--- a/internal/validate/path.go
+++ b/internal/validate/path.go
@@ -81,7 +81,8 @@ func ValidatePathParams(path, method string, params []*openapi.Parameter) []erro
 	matches := pathParamRe.FindAllStringSubmatch(path, -1)
 	templateNames := map[string]struct{}{}
 	for _, match := range matches {
-		templateNames[match[1]] = struct{}{}
+		name, _, _ := strings.Cut(match[1], ":")
+		templateNames[name] = struct{}{}
 	}
 	declared := map[string]bool{}
 	for _, p := range params {
@@ -104,7 +105,7 @@ func ValidatePathParams(path, method string, params []*openapi.Parameter) []erro
 		}
 	}
 	for _, match := range matches {
-		name := match[1]
+		name, _, _ := strings.Cut(match[1], ":")
 		if required, ok := declared[name]; !ok {
 			errs = append(errs, Errorf("%s %s missing path parameter %q", strings.ToUpper(method), path, name))
 		} else if !required {

--- a/internal/validate/utils.go
+++ b/internal/validate/utils.go
@@ -14,7 +14,7 @@ import (
 )
 
 var (
-	pathParamRe    = regexp.MustCompile(`\{([^{}]+)\}`)
+	pathParamRe    = regexp.MustCompile(`\{([^{}]*(?:\{[^{}]*\}[^{}]*)*)\}`)
 	componentRe    = regexp.MustCompile(`^[a-zA-Z0-9.\-_]+$`)
 	responseCodeRe = regexp.MustCompile(`^[1-5]([0-9]{2}|XX)$`)
 )

--- a/internal/validate/utils.go
+++ b/internal/validate/utils.go
@@ -14,7 +14,7 @@ import (
 )
 
 var (
-	pathParamRe    = regexp.MustCompile(`\{([^{}]*(?:\{[^{}]*\}[^{}]*)*)\}`)
+	pathParamRe    = regexp.MustCompile(`\{((?:\\.|[^{}\\]|\{(?:\\.|[^{}\\])*\})*)\}`)
 	componentRe    = regexp.MustCompile(`^[a-zA-Z0-9.\-_]+$`)
 	responseCodeRe = regexp.MustCompile(`^[1-5]([0-9]{2}|XX)$`)
 )

--- a/internal/validate/utils_test.go
+++ b/internal/validate/utils_test.go
@@ -14,6 +14,16 @@ import (
 func TestNormalizeTemplatedPath(t *testing.T) {
 	assert.Equal(t, "/users/{}", validate.NormalizeTemplatedPath("/users/{id}"))
 	assert.Equal(t, "/orgs/{}/repos/{}", validate.NormalizeTemplatedPath("/orgs/{org}/repos/{repo}"))
+	assert.Equal(t, "/type/{}", validate.NormalizeTemplatedPath("/type/{type:foo|bar}"))
+	assert.Equal(t, "/more/{}/{}", validate.NormalizeTemplatedPath("/more/{param}/{type:foo|bar}"))
+	assert.Equal(t, "/complex/quantifier/{}", validate.NormalizeTemplatedPath("/complex/quantifier/{t:(\\d{4})}"))
+	assert.Equal(
+		t,
+		"/foo/bar/{}/two/{}/8/nine/{}",
+		validate.NormalizeTemplatedPath("/foo/bar/{one}/two/{three:(four|five){6,7}(eight|nine)}/8/nine/{wtf}"),
+	)
+	assert.Equal(t, "/empty/{}", validate.NormalizeTemplatedPath("/empty/{type:}"))
+	assert.Equal(t, "/escaped/{}", validate.NormalizeTemplatedPath("/escaped/{type:foo\\{bar\\}}"))
 	assert.Equal(t, "/static", validate.NormalizeTemplatedPath("/static"))
 }
 

--- a/internal/validate/utils_test.go
+++ b/internal/validate/utils_test.go
@@ -22,6 +22,7 @@ func TestNormalizeTemplatedPath(t *testing.T) {
 		"/foo/bar/{}/two/{}/8/nine/{}",
 		validate.NormalizeTemplatedPath("/foo/bar/{one}/two/{three:(four|five){6,7}(eight|nine)}/8/nine/{wtf}"),
 	)
+	assert.Equal(t, "/curly/brace/{}/{}", validate.NormalizeTemplatedPath(`/curly/brace/{one:\{}/{two:\}\}}`))
 	assert.Equal(t, "/static", validate.NormalizeTemplatedPath("/static"))
 }
 

--- a/internal/validate/utils_test.go
+++ b/internal/validate/utils_test.go
@@ -22,8 +22,6 @@ func TestNormalizeTemplatedPath(t *testing.T) {
 		"/foo/bar/{}/two/{}/8/nine/{}",
 		validate.NormalizeTemplatedPath("/foo/bar/{one}/two/{three:(four|five){6,7}(eight|nine)}/8/nine/{wtf}"),
 	)
-	assert.Equal(t, "/empty/{}", validate.NormalizeTemplatedPath("/empty/{type:}"))
-	assert.Equal(t, "/escaped/{}", validate.NormalizeTemplatedPath("/escaped/{type:foo\\{bar\\}}"))
 	assert.Equal(t, "/static", validate.NormalizeTemplatedPath("/static"))
 }
 


### PR DESCRIPTION
## Description

this PR fixes a bug where path/template params with regex constraints (`/sub/path/{type:something|orother}`) are parsed incorrectly, resulting in validation errors when trying to marshal documents to YAML/JSON. given the previous example, `{type:something|orother}` would result in a template param with the name `type:something|orother`, instead of `type`.


## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor / code quality
- [ ] Other (describe):

## Checklist

- [x] `make check` passes locally (sync + tidy + lint + test)
- [x] Tests added or updated to cover the change
- [x] Golden files updated if spec output changed (`make test-update`)
- [ ] Relevant documentation updated (README, adapter README, etc.)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
